### PR TITLE
Save a read-after-write on auto-generated lockfiles

### DIFF
--- a/test/resolve_test.rb
+++ b/test/resolve_test.rb
@@ -843,7 +843,7 @@ INFO
           lockfile: nil,
           catalog_options: { cache: cache_dir },
           **options,
-        )
+        ).dump
 
         assert_match(/\AFetching sources\.\.\.+\nResolving dependencies\.\.\.+\n\z/, output.string)
       end


### PR DESCRIPTION
I didn't love the feel of `read_lockfile`, so wanted to try a different approach.

Also:
* fixed some indentation
* mirrored the auto-lock behaviour into `activate_for_executable` (tbh, I'm a bit undecided whether that path should ever write a lockfile, but for now we should probably keep them in sync)
* pass along `output`, so auto-lock doesn't talk to `$stdout` when we're supposed to be silent

wdyt?